### PR TITLE
Only list bookings when booking is enabled

### DIFF
--- a/src/Resources/contao/dca/tl_calendar_events.php
+++ b/src/Resources/contao/dca/tl_calendar_events.php
@@ -207,23 +207,29 @@ class tl_calendar_event_booking extends tl_calendar_events
      */
     public function listEvents($arrRow)
     {
-        $countBookings = CalendarEventsMemberModel::countBy('pid', $arrRow['id']);
-        $span = Calendar::calculateSpan($arrRow['startTime'], $arrRow['endTime']);
+        if ($arrRow['addBookingForm'])
+        {
+            $countBookings = CalendarEventsMemberModel::countBy('pid', $arrRow['id']);
+            $span = Calendar::calculateSpan($arrRow['startTime'], $arrRow['endTime']);
 
-        if ($span > 0)
-        {
-            $date = Date::parse(Config::get(($arrRow['addTime'] ? 'datimFormat' : 'dateFormat')), $arrRow['startTime']) . $GLOBALS['TL_LANG']['MSC']['cal_timeSeparator'] . Date::parse(Config::get(($arrRow['addTime'] ? 'datimFormat' : 'dateFormat')), $arrRow['endTime']);
-        }
-        elseif ($arrRow['startTime'] == $arrRow['endTime'])
-        {
-            $date = Date::parse(Config::get('dateFormat'), $arrRow['startTime']) . ($arrRow['addTime'] ? ' ' . Date::parse(Config::get('timeFormat'), $arrRow['startTime']) : '');
-        }
-        else
-        {
-            $date = Date::parse(Config::get('dateFormat'), $arrRow['startTime']) . ($arrRow['addTime'] ? ' ' . Date::parse(Config::get('timeFormat'), $arrRow['startTime']) . $GLOBALS['TL_LANG']['MSC']['cal_timeSeparator'] . Date::parse(Config::get('timeFormat'), $arrRow['endTime']) : '');
-        }
+            if ($span > 0)
+            {
+                $date = Date::parse(Config::get(($arrRow['addTime'] ? 'datimFormat' : 'dateFormat')), $arrRow['startTime']) . $GLOBALS['TL_LANG']['MSC']['cal_timeSeparator'] . Date::parse(Config::get(($arrRow['addTime'] ? 'datimFormat' : 'dateFormat')), $arrRow['endTime']);
+            }
+            elseif ($arrRow['startTime'] == $arrRow['endTime'])
+            {
+                $date = Date::parse(Config::get('dateFormat'), $arrRow['startTime']) . ($arrRow['addTime'] ? ' ' . Date::parse(Config::get('timeFormat'), $arrRow['startTime']) : '');
+            }
+            else
+            {
+                $date = Date::parse(Config::get('dateFormat'), $arrRow['startTime']) . ($arrRow['addTime'] ? ' ' . Date::parse(Config::get('timeFormat'), $arrRow['startTime']) . $GLOBALS['TL_LANG']['MSC']['cal_timeSeparator'] . Date::parse(Config::get('timeFormat'), $arrRow['endTime']) : '');
+            }
 
-        return '<div class="tl_content_left">' . $arrRow['title'] . ' <span style="color:#999;padding-left:3px">[' . $date . ']</span><span style="color:#999;padding-left:3px">[' . $GLOBALS['TL_LANG']['MSC']['bookings'] . ': ' . $countBookings . 'x]</span></div>';
+            return '<div class="tl_content_left">' . $arrRow['title'] . ' <span style="color:#999;padding-left:3px">[' . $date . ']</span><span style="color:#999;padding-left:3px">[' . $GLOBALS['TL_LANG']['MSC']['bookings'] . ': ' . $countBookings . 'x]</span></div>';
+        }
+        else 
+        {
+            return parent::listEvents($arrRow);
+        }
     }
-
 }


### PR DESCRIPTION
Dieser PR verbessert die Darstellung in der Event-Liste. Es wird der Text `[Buchungen xx]` nur angezeigt, wenn das Buchungsformular für das Event aktiviert wurde. So kann man in der Liste leichter erkennen, welche Events buchbar sind und welche nicht.