### PR TITLE
Feature tokens

### DIFF
--- a/src/Resources/contao/classes/hooks/ValidateForms.php
+++ b/src/Resources/contao/classes/hooks/ValidateForms.php
@@ -265,13 +265,13 @@ class ValidateForms
                 $row = $objEventMember->row();
                 foreach ($row as $k => $v)
                 {
-                    $arrTokens[$k] = html_entity_decode($v);
+                    $arrTokens['member_' . $k] = html_entity_decode($v);
                 }
 
                 $row = $objEvent->row();
                 foreach ($row as $k => $v)
                 {
-                    $arrTokens[$k] = html_entity_decode($v);
+                    $arrTokens['event_' . $k] = html_entity_decode($v);
                 }
 
                 $objUser = UserModel::findByPk($objEvent->eventBookingNotificationSender);
@@ -281,21 +281,21 @@ class ValidateForms
                     $arrTokens['senderEmail'] = $objUser->email;
                 }
 
-                $arrTokens['gender'] = html_entity_decode($GLOBALS['TL_LANG']['tl_calendar_events_member'][$objEventMember->gender]);
-                $arrTokens['eventtitle'] = html_entity_decode($objEvent->title);
+                $arrTokens['member_gender'] = html_entity_decode($GLOBALS['TL_LANG']['tl_calendar_events_member'][$objEventMember->gender]);
+                $arrTokens['event_title'] = html_entity_decode($objEvent->title);
                 if ($objEvent->addTime)
                 {
-                    $arrTokens['startTime'] = Date::parse(Config::get('timeFormat'), $objEvent->startTime);
-                    $arrTokens['endTime'] = Date::parse(Config::get('timeFormat'), $objEvent->endTime);
+                    $arrTokens['event_startTime'] = Date::parse(Config::get('timeFormat'), $objEvent->startTime);
+                    $arrTokens['event_endTime'] = Date::parse(Config::get('timeFormat'), $objEvent->endTime);
                 }
                 else
                 {
-                    $arrTokens['startTime'] = '';
-                    $arrTokens['endTime'] = '';
+                    $arrTokens['event_startTime'] = '';
+                    $arrTokens['event_endTime'] = '';
                 }
-                $arrTokens['startDate'] = Date::parse(Config::get('dateFormat'), $objEvent->startDate);
-                $arrTokens['endDate'] = Date::parse(Config::get('dateFormat'), $objEvent->endDate);
-                $arrTokens['dateOfBirth'] = Date::parse(Config::get('dateFormat'), $objEventMember->dateOfBirth);
+                $arrTokens['event_startDate'] = Date::parse(Config::get('dateFormat'), $objEvent->startDate);
+                $arrTokens['event_endDate'] = Date::parse(Config::get('dateFormat'), $objEvent->endDate);
+                $arrTokens['member_dateOfBirth'] = Date::parse(Config::get('dateFormat'), $objEventMember->dateOfBirth);
 
                 // Send notification (multiple notifications possible)
                 foreach ($arrNotifications as $notificationId)

--- a/src/Resources/contao/classes/hooks/ValidateForms.php
+++ b/src/Resources/contao/classes/hooks/ValidateForms.php
@@ -281,7 +281,7 @@ class ValidateForms
                     $arrTokens['senderEmail'] = $objUser->email;
                 }
 
-                $arrTokens['member_gender'] = html_entity_decode($GLOBALS['TL_LANG']['tl_calendar_events_member'][$objEventMember->gender]);
+                $arrTokens['member_salution'] = html_entity_decode($GLOBALS['TL_LANG']['tl_calendar_events_member'][$objEventMember->gender]);
                 $arrTokens['event_title'] = html_entity_decode($objEvent->title);
                 if ($objEvent->addTime)
                 {

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -34,14 +34,14 @@ $GLOBALS['NOTIFICATION_CENTER']['NOTIFICATION_TYPE']['calendar-event-booking-bun
     'booking-notification' => array
     (
         // Field in tl_nc_language
-        'email_sender_name'    => array('senderName', 'lastname', 'firstname'),
-        'email_sender_address' => array('senderEmail', 'email'),
-        'recipients'           => array('senderEmail', 'email'),
-        'email_recipient_cc'   => array('senderEmail', 'email'),
-        'email_recipient_bcc'  => array('senderEmail', 'email'),
+        'email_sender_name'    => array('senderName', 'member_lastname', 'member_firstname'),
+        'email_sender_address' => array('senderEmail', 'member_email'),
+        'recipients'           => array('senderEmail', 'member_email'),
+        'email_recipient_cc'   => array('senderEmail', 'member_email'),
+        'email_recipient_bcc'  => array('senderEmail', 'member_email'),
         'email_replyTo'        => array('senderEmail'),
-        'email_subject'        => array('gender', 'firstname', 'lastname', 'street', 'postal', 'city', 'phone', 'email', 'street', 'startDate', 'endDate', 'eventtitle', 'escorts', 'senderName', 'senderEmail'),
-        'email_text'           => array('gender', 'firstname', 'lastname', 'street', 'postal', 'city', 'phone', 'email', 'street', 'startDate', 'endDate', 'eventtitle', 'escorts', 'senderName', 'senderEmail'),
-        'email_html'           => array('gender', 'firstname', 'lastname', 'street', 'postal', 'city', 'phone', 'email', 'street', 'startDate', 'endDate', 'eventtitle', 'escorts', 'senderName', 'senderEmail'),
+        'email_subject'        => array('event_*', 'member_*', 'senderName', 'senderEmail'),
+        'email_text'           => array('event_*', 'member_*', 'senderName', 'senderEmail'),
+        'email_html'           => array('event_*', 'member_*', 'senderName', 'senderEmail'),
     ),
 );


### PR DESCRIPTION
Dieser PR behebt folgende Probleme: 
Erstellt man eine Benachrichtigung, in der z.B. die Tokens  street, postal oder city verwendet werden, werden immer nur die Felder aus dem Event übermittelt. Konkret besteht das Problem hier:
https://github.com/markocupic/calendar-event-booking-bundle/blob/d70c7e0d73f49fed3bfad7a2c58f544c79e2cc36/src/Resources/contao/classes/hooks/ValidateForms.php#L263-L282

Hier werden die Tokens aus dem Member Objekt durch die des Events überschrieben, sofern sie gleich heißen. Der PR setzt entsprechende Präfixe, um dieses Problem zu umgehen.

Weiterhin wird der Simple-Token gender derzeit nach "Herr" bzw. "Frau" übersetzt. Für If-Else Tokens ist das nicht so komfortabel, weswegen die Übersetzung in salutions (Anrede) umbenannt wurde, um den Token gender direkt mit male oder female abzufragen.

Dieser PR bietet weiterhin die Möglichkeit nicht nur fest definierte Felder aus dem Member oder Event Objekt zu verwenden, sondern auch weitere wie company und selbst angelegte Felder.

**Achtung!** Da die Tokens geändert werden, ist dieser PR nicht unbedingt mit der Version 2 kompatibel. Ggf. müsste auch der Doku Screenshot angepasst werden.