### PR TITLE
Update config.php --> added member_email to replyTo

### DIFF
--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -54,7 +54,7 @@ $GLOBALS['NOTIFICATION_CENTER']['NOTIFICATION_TYPE']['calendar-event-booking-bun
 		'recipients'           => array('organizer_senderEmail', 'member_email'),
 		'email_recipient_cc'   => array('organizer_senderEmail', 'member_email'),
 		'email_recipient_bcc'  => array('organizer_senderEmail', 'member_email'),
-		'email_replyTo'        => array('organizer_senderEmail'),
+		'email_replyTo'        => array('organizer_senderEmail', 'member_email'),
 		'email_subject'        => array('event_*', 'event_unsubscribeHref', 'member_*', 'member_dateOfBirthFormated', 'member_salutation', 'organizer_*', 'organizer_senderName', 'organizer_senderEmail'),
 		'email_text'           => array('event_*', 'event_unsubscribeHref', 'member_*', 'member_dateOfBirthFormated', 'member_salutation', 'organizer_*', 'organizer_senderName', 'organizer_senderEmail'),
 		'email_html'           => array('event_*', 'event_unsubscribeHref', 'member_*', 'member_dateOfBirthFormated', 'member_salutation', 'organizer_*', 'organizer_senderName', 'organizer_senderEmail'),


### PR DESCRIPTION
In NC / reply-to field member_email is not selectable in the current version. Now it works (tested).

Explanation: We get bookings with questions and have to reply often to these mails. With this small modification we can now reply directly to the customers.