### PR TITLE
Abmeldefrist-Zeitpunkt | Umgewandeltes dateformat in den Benachrichtigungen

### DIFF
--- a/src/Notification/NotificationHelper.php
+++ b/src/Notification/NotificationHelper.php
@@ -99,6 +99,17 @@ class NotificationHelper
             $arrTokens['event_endTime'] = '';
         }
 
+        // event unsubscribeLimitTstamp
+        if($objEvent->unsubscribeLimitTstamp) {
+            $arrTokens['event_unsubscribeLimitTstamp'] = $dateAdapter->parse($configAdapter->get('timeFormat'), $objEvent->unsubscribeLimitTstamp);
+        } else {
+            $arrTokens['event_unsubscribeLimitTstamp'] = '';
+        }
+
+        if(is_numeric($objEvent->unsubscribeLimitTstamp)) {
+            $arrTokens['event_unsubscribeLimitTstamp'] = $dateAdapter->parse($configAdapter->get('datimFormat'), $objEvent->endDate);
+        }
+
         // event title
         $arrTokens['event_title'] = html_entity_decode((string) $objEvent->title);
 


### PR DESCRIPTION
Durch die Änderung ist es möglich den Abmeldefrist-Zeitpunkt in einem für den Nutzer verständlichen Datumsformat in den Benachrichtigungen, beispielsweise in einer Email, über die Simple Tokens zu verwenden.

```php
##event_unsubscribeLimitTstamp##
```

Zuvor konnte dieser Wert nur als Timestamp ausgegeben werden.